### PR TITLE
Updates and fixes for using main instead of develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "husky": "^7.0.4",
+        "jest-axe": "^5.0.1",
         "lint-staged": "^12.1.5",
         "prettier": "^2.5.1"
       }
@@ -10178,6 +10179,61 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-axe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-5.0.1.tgz",
+      "integrity": "sha512-MMOWA6gT4pcZGbTLS8ZEqABH08Lnj5bInfLPpn9ADWX2wFF++odbbh8csmSfkwKjHaioVPzlCtIypAtxFDx/rw==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "4.2.1",
+        "chalk": "4.1.0",
+        "jest-matcher-utils": "27.0.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz",
+      "integrity": "sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
+      "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.0.2",
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-changed-files": {
@@ -28171,37 +28227,6 @@
         "lodash.merge": "4.6.2"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "axe-core": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz",
@@ -28218,51 +28243,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-          "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "27.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
-          "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.4.0",
-            "jest-get-type": "^27.4.0",
-            "pretty-format": "^27.4.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz",
-          "integrity": "sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==",
-          "dev": true
-        },
         "jest-matcher-utils": {
           "version": "27.0.2",
           "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
@@ -28273,41 +28253,6 @@
             "jest-diff": "^27.0.2",
             "jest-get-type": "^27.0.1",
             "pretty-format": "^27.0.2"
-          }
-        },
-        "pretty-format": {
-          "version": "27.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
-          "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.2",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -31,15 +31,4 @@ describe("test the router function", () => {
 
     expect(screen.getByText(/Home Page/i)).toBeInTheDocument();
   });
-
-});
-
-
-expect.extend(toHaveNoViolations);
-
-it("should pass axe accessibility tests", async () => {
-    const { container } = render(<App />);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
 });

--- a/src/components/About/About.test.js
+++ b/src/components/About/About.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { About } from "./About";
-
+import { axe, toHaveNoViolations } from "jest-axe";
 window.open = jest.fn(); // mock window.open for testing the buttons
 
 describe("Test the About page", () => {
@@ -79,5 +79,18 @@ describe("Test the About page", () => {
     fireEvent.click(getByText("ECMPS 2.0 Application"));
 
     expect(container.querySelector(".usa-button")).toBeInTheDocument();
+  });
+
+  expect.extend(toHaveNoViolations);
+
+  it("should pass axe accessibility tests", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <About />
+      </MemoryRouter>
+    );
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 });

--- a/src/components/HomePage.test.js
+++ b/src/components/HomePage.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { HomePage } from "./HomePage";
+import { axe, toHaveNoViolations } from "jest-axe";
 
 test("renders the home page", () => {
   render(
@@ -12,4 +13,17 @@ test("renders the home page", () => {
 
   const linkElement = screen.getByText(/About CAM API/i);
   expect(linkElement).toBeInTheDocument();
+});
+
+expect.extend(toHaveNoViolations);
+
+it("should pass axe accessibility tests", async () => {
+  const { container } = render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>
+  );
+  const results = await axe(container);
+
+  expect(results).toHaveNoViolations();
 });

--- a/src/components/Layout.test.js
+++ b/src/components/Layout.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Layout } from "./Layout";
+import { axe, toHaveNoViolations } from "jest-axe";
 
 test.todo("render the subheader for the CAM API pages");
 //, () => {
@@ -14,3 +15,16 @@ test.todo("render the subheader for the CAM API pages");
 //   const linkElement = screen.getByText(/CAM-API-Portal Subheader/i);
 //   expect(linkElement).toBeInTheDocument();
 //});
+
+expect.extend(toHaveNoViolations);
+
+it("should pass axe accessibility tests", async () => {
+  const { container } = render(
+    <MemoryRouter>
+      <Layout />
+    </MemoryRouter>
+  );
+  const results = await axe(container);
+
+  expect(results).toHaveNoViolations();
+});

--- a/src/components/NotFoundPage.test.js
+++ b/src/components/NotFoundPage.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { NotFoundPage } from "./NotFoundPage";
+import { axe, toHaveNoViolations } from "jest-axe";
 
 test("renders the NotFound page with 404 message", () => {
   render(
@@ -23,4 +24,17 @@ test("renders the NotFound page with Page Not Found message", () => {
 
   const linkElement = screen.getByText(/Page Not Found/i);
   expect(linkElement).toBeInTheDocument();
+});
+
+expect.extend(toHaveNoViolations);
+
+it("should pass axe accessibility tests", async () => {
+  const { container } = render(
+    <MemoryRouter>
+      <NotFoundPage />
+    </MemoryRouter>
+  );
+  const results = await axe(container);
+
+  expect(results).toHaveNoViolations();
 });


### PR DESCRIPTION
We should be using the default branch for our development. It will ease our GitHub Action workflows, dependabot pull-requests, and set us up nicely for semantic release