### PR TITLE
Removed management from streaming services api

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -32,7 +32,7 @@ export const constants = {
     {
       name: "streaming-services",
       url: "https://api.epa.gov/easey/streaming-services/swagger-json",
-      title: "Streaming Services Management",
+      title: "Streaming Services",
       description:
         "Streaming services API contains endpoints to stream account, allowance, facilities, and emissions data",
     },
@@ -67,7 +67,7 @@ export const constants = {
       publish: "Thu Mar 24 2022",
     },
     {
-      title: "Streaming Services Management",
+      title: "Streaming Services",
       description:
         "Streaming services API contains endpoints to stream account, allowance, facilities, and emissions data",
       version: "v1.0.5",


### PR DESCRIPTION
Removed the "management" text wherever the streaming services API is referenced.