### PR TITLE
Remove css class for API Docs card header

### DIFF
--- a/src/components/APIDocs/APIDocs.js
+++ b/src/components/APIDocs/APIDocs.js
@@ -42,10 +42,7 @@ export const APIDocs = () => {
                   align="left"
                 >
                   <CardHeader>
-                    <h2
-                      className="usa-card__heading"
-                      aria-label={`${page.title} API documents card`}
-                    >
+                    <h2 aria-label={`${page.title} API documents card`}>
                       {page.title}
                     </h2>
                   </CardHeader>


### PR DESCRIPTION
Fixes a mismatch in fonts between the APIDocs cards to the homepage cards